### PR TITLE
enable use_pip and sanity_pip_check in ANGEL easyconfig

### DIFF
--- a/easybuild/easyconfigs/a/ANGEL/ANGEL-3.0-foss-2019a-Python-3.7.2.eb
+++ b/easybuild/easyconfigs/a/ANGEL/ANGEL-3.0-foss-2019a-Python-3.7.2.eb
@@ -31,8 +31,7 @@ dependencies = [
 ]
 
 download_dep_fail = True
-
-use_pip = False
+use_pip = True
 
 local_bin_files = [
     'dumb_predict.py',
@@ -46,7 +45,9 @@ options = {'modulename': False}
 
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in local_bin_files],
-    'dirs': [''],
+    'dirs': [],
 }
+
+sanity_pip_check = True
 
 moduleclass = 'bio'


### PR DESCRIPTION
@robqiao For https://github.com/easybuilders/easybuild-easyconfigs/pull/11857 .

I see no reason not to enable `use_pip`, installation works fine for me when it's enabled...